### PR TITLE
Swap open/closed limits in 2 places in docs

### DIFF
--- a/ndhistogram/src/axis/uniform.rs
+++ b/ndhistogram/src/axis/uniform.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 /// An axis with equal sized bins.
 ///
-/// An axis with N equally spaced, equal sized, bins between (low, high].
+/// An axis with N equally spaced, equal sized, bins between [low, high).
 /// Below (above) this range is an underflow (overflow) bin.
 /// Hence this axis has N+2 bins.
 ///

--- a/ndhistogram/src/axis/uniformnoflow.rs
+++ b/ndhistogram/src/axis/uniformnoflow.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 /// An axis with equal sized bins and no under/overflow bins.
 ///
-/// An axis with N equally spaced, equal sized, bins between (low, high].
+/// An axis with N equally spaced, equal sized, bins between [low, high).
 /// Similar to [Uniform] but this axis has no over/underflow bins.
 /// Hence it has N bins.
 ///


### PR DESCRIPTION
Just a trivial change in the docs: in a couple of places the intervals were advertised as open-closed, when in reality they are closed-open.

There are two more PRs I'm considering contributing, please let me know if you would be interested:

1. Another docs PR, this time purely cosmetic, the meaning won't change. There are numerous places in the text of the docs where Rust expressions are not marked-up as code. The OCD in me wants to fix this. There are also some places where the text in `expect`s is not strictly correct. As I said, this is not vitally important, mostly cosmetic.
 
2.  I'm writing a wrap-around axis (for use with polar coordinates, but I imagine it might also be useful for in some more general modular arithmetic scenarios) that I need in a project of mine. If you're interested, I could try to flesh it out, polish it, and submit it as a PR.