### PR TITLE
Enable Rust cache on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: Swatinem/rust-cache@v1
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
@@ -26,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: Swatinem/rust-cache@v1
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
@@ -43,6 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: Swatinem/rust-cache@v1
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal


### PR DESCRIPTION
Caching Rust build products speeds up CI jobs.

Very rough estimate of the gains on the CI jobs that currently run in
this project:

+ Check: 1m -> 10s (85% speedup)
+ Test Suite: 2m30 -> 1m (60% speedup)
+ Lints: 2m30 -> 1m20 (50% speedup)
+ Publish: data unavailable