### PR TITLE
Rfoxkendo/issue30

### DIFF
--- a/ndhistogram/src/value/sum.rs
+++ b/ndhistogram/src/value/sum.rs
@@ -1,6 +1,7 @@
 use num_traits::Float;
 
 use crate::Fill;
+use crate::FillWith;
 
 /// ndhistogram bin value type for filling unweighted values.
 /// Analogous to [WeightedSum](crate::value::WeightedSum). Methods returning variance and standard
@@ -49,5 +50,16 @@ impl<T: Copy + Fill> Fill for Sum<T> {
     #[inline]
     fn fill(&mut self) {
         self.sum.fill();
+    }
+}
+
+impl<T, W> FillWith<W> for Sum<T>
+where
+    T: FillWith<W> + Copy,
+    W: Copy,
+{
+    #[inline]
+    fn fill_with(&mut self, weight: W) {
+        self.sum.fill_with(weight);
     }
 }

--- a/ndhistogram/tests/test_value_sum.rs
+++ b/ndhistogram/tests/test_value_sum.rs
@@ -1,4 +1,4 @@
-use ndhistogram::{axis::Uniform, ndhistogram, value::Sum, Histogram};
+use ndhistogram::{axis::Uniform, ndhistogram, value::Sum, Histogram, FillWith};
 #[test]
 fn test_sum_value_fill() {
     let mut hist = ndhistogram!(Uniform::new(1, 0.0, 1.0); Sum<i32>);
@@ -19,4 +19,11 @@ fn test_sum_value_error() {
     assert_float_eq(binvalue.get(), 2.0);
     assert_float_eq(binvalue.variance(), 2.0);
     assert_float_eq(binvalue.standard_deviation(), 2.0f64.sqrt());
+}
+
+#[test]
+fn test_sum_value_fill_with() {
+    let mut v = Sum::new();
+    v.fill_with(12345.678);
+    assert_float_eq(v.get(), 12345.678);
 }

--- a/ndhistogram/tests/test_value_sum.rs
+++ b/ndhistogram/tests/test_value_sum.rs
@@ -1,4 +1,4 @@
-use ndhistogram::{axis::Uniform, ndhistogram, value::Sum, Histogram, FillWith};
+use ndhistogram::{axis::Uniform, ndhistogram, value::Sum, FillWith, Histogram};
 #[test]
 fn test_sum_value_fill() {
     let mut hist = ndhistogram!(Uniform::new(1, 0.0, 1.0); Sum<i32>);


### PR DESCRIPTION
Reformatted the test using cargo fmt -- thanks for the pointer... I guess it was unhappy the submodules in my use were not in alphabetical order.  Hopefully the lint action will be happy now.